### PR TITLE
pwdコマンドを実装＆テストを追加

### DIFF
--- a/srcs/builtin/process_pwd.c
+++ b/srcs/builtin/process_pwd.c
@@ -1,6 +1,5 @@
 #include "../../include/minishell.h"
 
-
 int process_pwd(void)
 {
     char *str;
@@ -10,6 +9,7 @@ int process_pwd(void)
     if (str == NULL)
         return (1);
     ft_putendl_fd(str, STDOUT_FILENO);
+    free(str);
     return (0);
 }
 /*

--- a/srcs/builtin/process_pwd.c
+++ b/srcs/builtin/process_pwd.c
@@ -1,0 +1,58 @@
+#include "../../include/minishell.h"
+
+
+int process_pwd(void)
+{
+    char *str;
+
+    str = NULL;
+    str = getcwd(NULL, 0);
+    if (str == NULL)
+        return (1);
+    ft_putendl_fd(str, STDOUT_FILENO);
+    return (0);
+}
+/*
+ //cc -Wall -Wextra -Werror process_pwd.c -I../../include -L../../libft -lft -o process_pwd
+int main(void)
+{
+    process_pwd();
+    return (0);
+}
+*/
+/*
+requirements:pwd with no options
+
+   man bash
+
+ pwd [-LP]
+              Print  the  absolute  pathname of the current working directory.
+              The pathname printed contains no symbolic links if the -P option
+              is supplied or the -o physical option to the set builtin command
+              is enabled.  If the -L option is used, the pathname printed  may
+              contain  symbolic links.  The return status is 0 unless an error
+              occurs while reading the name of the current directory or an in‐
+              valid option is supplied.
+ 
+
+DESCRIPTION-getcwd
+       These  functions return a null-terminated string containing an absolute
+       pathname that is the current working directory of the calling  process.
+       The  pathname  is  returned as the function result and via the argument
+       buf, if present.
+
+       The getcwd() function copies an absolute pathname of the current  work‐
+       ing directory to the array pointed to by buf, which is of length size.
+
+       If  the  length  of the absolute pathname of the current working direc‐
+       tory, including the terminating null byte, exceeds size bytes, NULL  is
+       returned,  and  errno is set to ERANGE; an application should check for
+       this error, and allocate a larger buffer if necessary.
+
+       As an extension to the POSIX.1-2001 standard,  glibc's  getcwd()  allo‐
+       cates  the  buffer dynamically using malloc(3) if buf is NULL.  In this
+       case, the allocated buffer has the length size  unless  size  is  zero,
+       when  buf  is allocated as big as necessary.  The caller should free(3)
+       the returned buffer.
+              
+*/


### PR DESCRIPTION
# PWDコマンドの実装

カレントワーキングディレクトリを表示するPWDコマンドを実装しました。
getcwd関数を使用し、シンプルで堅牢な実装を心がけています。

## 実装の概要
- getcwd関数を使用してカレントディレクトリのパスを取得
- 動的なメモリ割り当てとエラーハンドリングの実装
- 標準出力へのパス表示機能

## テスト方法
1. libftをmakeしておく
2.cc -Wall -Wextra -Werror process_pwd.c -I../../include -L../../libft -lft -o process_pwd



## 技術的な補足

・getcwd(NULL, 0)としている理由

getcwdのmanに以下のようにあります。
　　"glibc's  getcwd()  allo‐
       cates  the  buffer dynamically using malloc(3) if buf is NULL.  In this
       case, the allocated buffer has the length size  unless  size  is  zero,
       when  buf  is allocated as big as necessary.  The caller should free(3)
       the returned buffer."

つまり、NULLと0を指定することで、必要なバッファサイズを自動的に確保します。
確保されたメモリは動的に割り当てられるため、使用後にfree()による解放が必要です。



変更差分
https://github.com/arashi0-git/Minishell/commit/1525087e56c039e9e2e2512f7eca9ccc26d7fb31
https://github.com/arashi0-git/Minishell/commit/a6d85c96724c4a3e65e5966c8113459ba6b4f4bf